### PR TITLE
Move cache options construction to ArrayReaderBuilder, add builders

### DIFF
--- a/parquet/src/arrow/array_reader/mod.rs
+++ b/parquet/src/arrow/array_reader/mod.rs
@@ -48,7 +48,7 @@ mod struct_array;
 mod test_util;
 
 // Note that this crate is public under the `experimental` feature flag.
-pub use builder::{ArrayReaderBuilder, CacheOptions};
+pub use builder::{ArrayReaderBuilder, CacheOptions, CacheOptionsBuilder};
 pub use byte_array::make_byte_array_reader;
 pub use byte_array_dictionary::make_byte_array_dictionary_reader;
 #[allow(unused_imports)] // Only used for benchmarks


### PR DESCRIPTION
- This is another proposed PR to https://github.com/apache/arrow-rs/pull/7850

It moves the management of the cache into their own structures:
1. Adds `CacheOptionBuilder`
2. Adds the CacheOptions as a field on `ArrayReaderBuilder` and removes `build_array_reader_with_cache`