### PR TITLE
Add option to control predicate cache, documentation, `ArrowReaderMetrics` and tests

### DIFF
--- a/parquet/examples/read_with_rowgroup.rs
+++ b/parquet/examples/read_with_rowgroup.rs
@@ -17,6 +17,7 @@
 
 use arrow::util::pretty::print_batches;
 use bytes::{Buf, Bytes};
+use parquet::arrow::arrow_reader::metrics::ArrowReaderMetrics;
 use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, RowGroups, RowSelection};
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::arrow::{parquet_to_arrow_field_levels, ProjectionMask};
@@ -38,7 +39,11 @@ async fn main() -> Result<()> {
     let metadata = file.get_metadata(None).await?;
 
     for rg in metadata.row_groups() {
-        let mut rowgroup = InMemoryRowGroup::create(rg.clone(), ProjectionMask::all());
+        let mut rowgroup = InMemoryRowGroup::create(
+            rg.clone(),
+            ProjectionMask::all(),
+            ArrowReaderMetrics::disabled(),
+        );
         rowgroup.async_fetch_data(&mut file, None).await?;
         let reader = rowgroup.build_reader(1024, None)?;
 
@@ -103,6 +108,7 @@ pub struct InMemoryRowGroup {
     pub metadata: RowGroupMetaData,
     mask: ProjectionMask,
     column_chunks: Vec<Option<Arc<ColumnChunkData>>>,
+    metrics: ArrowReaderMetrics,
 }
 
 impl RowGroups for InMemoryRowGroup {
@@ -132,13 +138,18 @@ impl RowGroups for InMemoryRowGroup {
 }
 
 impl InMemoryRowGroup {
-    pub fn create(metadata: RowGroupMetaData, mask: ProjectionMask) -> Self {
+    pub fn create(
+        metadata: RowGroupMetaData,
+        mask: ProjectionMask,
+        metrics: ArrowReaderMetrics,
+    ) -> Self {
         let column_chunks = metadata.columns().iter().map(|_| None).collect::<Vec<_>>();
 
         Self {
             metadata,
             mask,
             column_chunks,
+            metrics,
         }
     }
 
@@ -153,7 +164,13 @@ impl InMemoryRowGroup {
             None,
         )?;
 
-        ParquetRecordBatchReader::try_new_with_row_groups(&levels, self, batch_size, selection)
+        ParquetRecordBatchReader::try_new_with_row_groups(
+            &levels,
+            self,
+            batch_size,
+            selection,
+            &self.metrics,
+        )
     }
 
     /// fetch data from a reader in sync mode

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -249,6 +249,7 @@ mod tests {
     use crate::arrow::array_reader::list_array::ListArrayReader;
     use crate::arrow::array_reader::test_util::InMemoryArrayReader;
     use crate::arrow::array_reader::ArrayReaderBuilder;
+    use crate::arrow::arrow_reader::metrics::ArrowReaderMetrics;
     use crate::arrow::schema::parquet_to_arrow_schema_and_fields;
     use crate::arrow::{parquet_to_arrow_schema, ArrowWriter, ProjectionMask};
     use crate::file::properties::WriterProperties;
@@ -563,7 +564,8 @@ mod tests {
         )
         .unwrap();
 
-        let mut array_reader = ArrayReaderBuilder::new(&file_reader)
+        let metrics = ArrowReaderMetrics::disabled();
+        let mut array_reader = ArrayReaderBuilder::new(&file_reader, &metrics)
             .build_array_reader(fields.as_ref(), &mask)
             .unwrap();
 

--- a/parquet/src/arrow/arrow_reader/metrics.rs
+++ b/parquet/src/arrow/arrow_reader/metrics.rs
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [ArrowReaderMetrics] for collecting metrics about the Arrow reader
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+/// This enum represents the state of Arrow reader metrics collection.
+///
+/// The inner metrics are stored in an `Arc<ArrowReaderMetricsInner>`
+/// so cloning the `ArrowReaderMetrics` enum will not clone the inner metrics.
+///
+/// To access metrics, create an `ArrowReaderMetrics` via [`ArrowReaderMetrics::enabled()`]
+/// and configure the `ArrowReaderBuilder` with a clone.
+#[derive(Debug, Clone)]
+pub enum ArrowReaderMetrics {
+    /// Metrics are not collected (default)
+    Disabled,
+    /// Metrics are collected and stored in an `Arc`.
+    ///
+    /// Create this via [`ArrowReaderMetrics::enabled()`].
+    Enabled(Arc<ArrowReaderMetricsInner>),
+}
+
+impl ArrowReaderMetrics {
+    /// Creates a new instance of [`ArrowReaderMetrics::Disabled`]
+    pub fn disabled() -> Self {
+        Self::Disabled
+    }
+
+    /// Creates a new instance of [`ArrowReaderMetrics::Enabled`]
+    pub fn enabled() -> Self {
+        Self::Enabled(Arc::new(ArrowReaderMetricsInner::new()))
+    }
+
+    /// Predicate Cache: number of records read directly from the inner reader
+    ///
+    /// This is the total number of records read from the inner reader (that is
+    /// actually decoding). It measures the amount of work that could not be
+    /// avoided with caching.
+    ///
+    /// It returns the number of records read across all columns, so if you read
+    /// 2 columns each with 100 records, this will return 200.
+    ///
+    ///
+    /// Returns None if metrics are disabled.
+    pub fn records_read_from_inner(&self) -> Option<usize> {
+        match self {
+            Self::Disabled => None,
+            Self::Enabled(inner) => Some(
+                inner
+                    .records_read_from_inner
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            ),
+        }
+    }
+
+    /// Predicate Cache: number of records read from the cache
+    ///
+    /// This is the total number of records read from the cache actually
+    /// decoding). It measures the amount of work that was avoided with caching.
+    ///
+    /// It returns the number of records read across all columns, so if you read
+    /// 2 columns each with 100 records from the cache, this will return 200.
+    ///
+    /// Returns None if metrics are disabled.
+    pub fn records_read_from_cache(&self) -> Option<usize> {
+        match self {
+            Self::Disabled => None,
+            Self::Enabled(inner) => Some(
+                inner
+                    .records_read_from_cache
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            ),
+        }
+    }
+
+    /// Increments the count of records read from the inner reader
+    pub(crate) fn increment_inner_reads(&self, count: usize) {
+        let Self::Enabled(inner) = self else {
+            return;
+        };
+        inner
+            .records_read_from_inner
+            .fetch_add(count, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Increments the count of records read from the cache
+    pub(crate) fn increment_cache_reads(&self, count: usize) {
+        let Self::Enabled(inner) = self else {
+            return;
+        };
+
+        inner
+            .records_read_from_cache
+            .fetch_add(count, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// Holds the actual metrics for the Arrow reader.
+///
+/// Please see [`ArrowReaderMetrics`] for the public interface.
+#[derive(Debug)]
+pub struct ArrowReaderMetricsInner {
+    // Metrics for Predicate Cache
+    /// Total number of records read from the inner reader (uncached)
+    records_read_from_inner: AtomicUsize,
+    /// Total number of records read from previously cached pages
+    records_read_from_cache: AtomicUsize,
+}
+
+impl ArrowReaderMetricsInner {
+    /// Creates a new instance of `ArrowReaderMetricsInner`
+    pub(crate) fn new() -> Self {
+        Self {
+            records_read_from_inner: AtomicUsize::new(0),
+            records_read_from_cache: AtomicUsize::new(0),
+        }
+    }
+}

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -38,9 +38,11 @@ use crate::file::metadata::{ParquetMetaData, ParquetMetaDataReader};
 use crate::file::reader::{ChunkReader, SerializedPageReader};
 use crate::schema::types::SchemaDescriptor;
 
+use crate::arrow::arrow_reader::metrics::ArrowReaderMetrics;
 pub(crate) use read_plan::{ReadPlan, ReadPlanBuilder};
 
 mod filter;
+pub mod metrics;
 mod read_plan;
 mod selection;
 pub mod statistics;
@@ -112,6 +114,10 @@ pub struct ArrowReaderBuilder<T> {
     pub(crate) limit: Option<usize>,
 
     pub(crate) offset: Option<usize>,
+
+    pub(crate) metrics: ArrowReaderMetrics,
+
+    pub(crate) max_predicate_cache_size: usize,
 }
 
 impl<T: Debug> Debug for ArrowReaderBuilder<T> {
@@ -128,6 +134,7 @@ impl<T: Debug> Debug for ArrowReaderBuilder<T> {
             .field("selection", &self.selection)
             .field("limit", &self.limit)
             .field("offset", &self.offset)
+            .field("metrics", &self.metrics)
             .finish()
     }
 }
@@ -146,6 +153,8 @@ impl<T> ArrowReaderBuilder<T> {
             selection: None,
             limit: None,
             offset: None,
+            metrics: ArrowReaderMetrics::Disabled,
+            max_predicate_cache_size: 100 * 1024 * 1024, // 100MB default cache size
         }
     }
 
@@ -293,6 +302,59 @@ impl<T> ArrowReaderBuilder<T> {
     pub fn with_offset(self, offset: usize) -> Self {
         Self {
             offset: Some(offset),
+            ..self
+        }
+    }
+
+    /// Specify metrics collection during reading
+    ///
+    /// To access the metrics, create an [`ArrowReaderMetrics`] and pass a
+    /// clone of the provided metrics to the builder.
+    ///
+    /// For example:
+    ///
+    /// ```rust
+    /// # use std::sync::Arc;
+    /// # use bytes::Bytes;
+    /// # use arrow_array::{Int32Array, RecordBatch};
+    /// # use arrow_schema::{DataType, Field, Schema};
+    /// # use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder};
+    /// use parquet::arrow::arrow_reader::metrics::ArrowReaderMetrics;
+    /// # use parquet::arrow::ArrowWriter;
+    /// # let mut file: Vec<u8> = Vec::with_capacity(1024);
+    /// # let schema = Arc::new(Schema::new(vec![Field::new("i32", DataType::Int32, false)]));
+    /// # let mut writer = ArrowWriter::try_new(&mut file, schema.clone(), None).unwrap();
+    /// # let batch = RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))]).unwrap();
+    /// # writer.write(&batch).unwrap();
+    /// # writer.close().unwrap();
+    /// # let file = Bytes::from(file);
+    /// // Create metrics object to pass into the reader
+    /// let metrics = ArrowReaderMetrics::enabled();
+    /// let reader = ParquetRecordBatchReaderBuilder::try_new(file).unwrap()
+    ///   // Configure the builder to use the metrics by passing a clone
+    ///   .with_metrics(metrics.clone())
+    ///   // Build the reader
+    ///   .build().unwrap();
+    /// // .. read data from the reader ..
+    ///
+    /// // check the metrics
+    /// assert!(metrics.records_read_from_inner().is_some());
+    /// ```
+    pub fn with_metrics(self, metrics: ArrowReaderMetrics) -> Self {
+        Self { metrics, ..self }
+    }
+
+    /// Set the maximum size of the predicate cache in bytes.
+    ///
+    /// Defaults to 100MB
+    ///
+    /// This cache is used to store decoded arrays that are used in
+    /// predicate evaluation ([`Self::with_row_filter`]).
+    ///
+    /// Set to `usize::MAX` to use unlimited cache size.
+    pub fn with_max_predicate_cache_size(self, max_predicate_cache_size: usize) -> Self {
+        Self {
+            max_predicate_cache_size,
             ..self
         }
     }
@@ -707,23 +769,37 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
     ///
     /// Note: this will eagerly evaluate any `RowFilter` before returning
     pub fn build(self) -> Result<ParquetRecordBatchReader> {
+        let Self {
+            input,
+            metadata,
+            schema: _,
+            fields,
+            batch_size: _,
+            row_groups,
+            projection,
+            mut filter,
+            selection,
+            limit,
+            offset,
+            metrics,
+            // TODO: need to implement this for the sync reader
+            max_predicate_cache_size: _,
+        } = self;
+
         // Try to avoid allocate large buffer
         let batch_size = self
             .batch_size
-            .min(self.metadata.file_metadata().num_rows() as usize);
+            .min(metadata.file_metadata().num_rows() as usize);
 
-        let row_groups = self
-            .row_groups
-            .unwrap_or_else(|| (0..self.metadata.num_row_groups()).collect());
+        let row_groups = row_groups.unwrap_or_else(|| (0..metadata.num_row_groups()).collect());
 
         let reader = ReaderRowGroups {
-            reader: Arc::new(self.input.0),
-            metadata: self.metadata,
+            reader: Arc::new(input.0),
+            metadata,
             row_groups,
         };
 
-        let mut filter = self.filter;
-        let mut plan_builder = ReadPlanBuilder::new(batch_size).with_selection(self.selection);
+        let mut plan_builder = ReadPlanBuilder::new(batch_size).with_selection(selection);
 
         // Update selection based on any filters
         if let Some(filter) = filter.as_mut() {
@@ -734,22 +810,22 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
                 }
 
                 let mut cache_projection = predicate.projection().clone();
-                cache_projection.intersect(&self.projection);
+                cache_projection.intersect(&projection);
 
-                let array_reader = ArrayReaderBuilder::new(&reader)
-                    .build_array_reader(self.fields.as_deref(), predicate.projection())?;
+                let array_reader = ArrayReaderBuilder::new(&reader, &metrics)
+                    .build_array_reader(fields.as_deref(), predicate.projection())?;
 
                 plan_builder = plan_builder.with_predicate(array_reader, predicate.as_mut())?;
             }
         }
 
-        let array_reader = ArrayReaderBuilder::new(&reader)
-            .build_array_reader(self.fields.as_deref(), &self.projection)?;
+        let array_reader = ArrayReaderBuilder::new(&reader, &metrics)
+            .build_array_reader(fields.as_deref(), &projection)?;
 
         let read_plan = plan_builder
             .limited(reader.num_rows())
-            .with_offset(self.offset)
-            .with_limit(self.limit)
+            .with_offset(offset)
+            .with_limit(limit)
             .build_limited()
             .build();
 
@@ -943,8 +1019,9 @@ impl ParquetRecordBatchReader {
         row_groups: &dyn RowGroups,
         batch_size: usize,
         selection: Option<RowSelection>,
+        metrics: &ArrowReaderMetrics,
     ) -> Result<Self> {
-        let array_reader = ArrayReaderBuilder::new(row_groups)
+        let array_reader = ArrayReaderBuilder::new(row_groups, metrics)
             .build_array_reader(levels.levels.as_ref(), &ProjectionMask::all())?;
 
         let read_plan = ReadPlanBuilder::new(batch_size)

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -344,7 +344,7 @@ impl<T> ArrowReaderBuilder<T> {
         Self { metrics, ..self }
     }
 
-    /// Set the maximum size of the predicate cache in bytes.
+    /// Set the maximum size (per row group) of the predicate cache in bytes.
     ///
     /// Defaults to 100MB
     ///

--- a/parquet/tests/arrow_reader/mod.rs
+++ b/parquet/tests/arrow_reader/mod.rs
@@ -38,6 +38,7 @@ use std::sync::Arc;
 use tempfile::NamedTempFile;
 
 mod bad_data;
+mod predicate_cache;
 #[cfg(feature = "crc")]
 mod checksum;
 mod statistics;

--- a/parquet/tests/arrow_reader/mod.rs
+++ b/parquet/tests/arrow_reader/mod.rs
@@ -38,9 +38,10 @@ use std::sync::Arc;
 use tempfile::NamedTempFile;
 
 mod bad_data;
-mod predicate_cache;
 #[cfg(feature = "crc")]
 mod checksum;
+#[cfg(feature = "async")]
+mod predicate_cache;
 mod statistics;
 
 // returns a struct array with columns "int32_col", "float32_col" and "float64_col" with the specified values

--- a/parquet/tests/arrow_reader/predicate_cache.rs
+++ b/parquet/tests/arrow_reader/predicate_cache.rs
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Test for predicate cache in Parquet Arrow reader
+
+
+
+use arrow::array::ArrayRef;
+use std::sync::Arc;
+use parquet::arrow::arrow_reader::ArrowReaderOptions;
+use std::sync::LazyLock;
+use arrow::array::Int64Array;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use bytes::Bytes;
+use arrow_array::{RecordBatch, StringViewArray};
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+
+
+// 1. the predicate cache is not used when there are no filters
+#[test]
+fn test() {
+    let test = ParquetPredicateCacheTest::new()
+        .with_expected_cache_used(false);
+    let builder = test.sync_builder(ArrowReaderOptions::default());
+    test.run(builder);
+}
+
+
+// Test:
+// 2. the predicate cache is used when there are filters but the cache size is 0
+// 3. the predicate cache is used when there are filters and the cache size is greater than 0
+
+
+
+
+
+/// A test parquet file
+struct ParquetPredicateCacheTest {
+    bytes: Bytes,
+    expected_cache_used: bool,
+}
+impl ParquetPredicateCacheTest {
+    /// Create a new `TestParquetFile` with:
+    /// 3 columns: "a", "b", "c"
+    ///
+    /// 2 row groups, each with 200 rows
+    /// each data page has 100 rows
+    ///
+    /// Values of column "a" are 0..399
+    /// Values of column "b" are 400..799
+    /// Values of column "c" are alternating strings of length 12 and longer
+      fn new() -> Self {
+        Self {
+            bytes: TEST_FILE_DATA.clone(),
+            expected_cache_used: false,
+        }
+    }
+
+    /// Set whether the predicate cache is expected to be used
+    fn with_expected_cache_used(mut self, used: bool) -> Self{
+        self.expected_cache_used = used;
+        self
+    }
+
+    /// Return a [`ParquetRecordBatchReaderBuilder`] for reading this file
+    fn sync_builder(
+        &self,
+        options: ArrowReaderOptions,
+    ) -> ParquetRecordBatchReaderBuilder<Bytes> {
+        let reader = self.bytes.clone();
+        ParquetRecordBatchReaderBuilder::try_new_with_options(reader, options)
+            .expect("ParquetRecordBatchReaderBuilder")
+    }
+
+
+    /// Build the reader from the specified builder, reading all batches from it,
+    /// and asserts the
+    fn run(
+        &self,
+        builder: ParquetRecordBatchReaderBuilder<Bytes>,
+    ) {
+        let reader = builder.build().unwrap();
+        for batch in reader {
+            match batch {
+                Ok(_) => {}
+                Err(e) => panic!("Error reading batch: {e}"),
+            }
+        }
+        // TODO check if the cache was used
+    }
+}
+
+/// Create a parquet file in memory for testing. See [`test_file`] for details.
+static TEST_FILE_DATA: LazyLock<Bytes> = LazyLock::new(|| {
+    // Input batch has 400 rows, with 3 columns: "a", "b", "c"
+    // Note c is a different types (so the data page sizes will be different)
+    let a: ArrayRef = Arc::new(Int64Array::from_iter_values(0..400));
+    let b: ArrayRef = Arc::new(Int64Array::from_iter_values(400..800));
+    let c: ArrayRef = Arc::new(StringViewArray::from_iter_values((0..400).map(|i| {
+        if i % 2 == 0 {
+            format!("string_{i}")
+        } else {
+            format!("A string larger than 12 bytes and thus not inlined {i}")
+        }
+    })));
+
+    let input_batch = RecordBatch::try_from_iter(vec![("a", a), ("b", b), ("c", c)]).unwrap();
+
+    let mut output = Vec::new();
+
+    let writer_options = WriterProperties::builder()
+        .set_max_row_group_size(200)
+        .set_data_page_row_count_limit(100)
+        .build();
+    let mut writer =
+        ArrowWriter::try_new(&mut output, input_batch.schema(), Some(writer_options)).unwrap();
+
+    // since the limits are only enforced on batch boundaries, write the input
+    // batch in chunks of 50
+    let mut row_remain = input_batch.num_rows();
+    while row_remain > 0 {
+        let chunk_size = row_remain.min(50);
+        let chunk = input_batch.slice(input_batch.num_rows() - row_remain, chunk_size);
+        writer.write(&chunk).unwrap();
+        row_remain -= chunk_size;
+    }
+    writer.close().unwrap();
+    Bytes::from(output)
+});


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/pull/7850

Merging this PR will update the apache PR https://github.com/apache/arrow-rs/pull/7850

# Rationale for this change

We need a way to turn off predicate caching as an escape valve for users who run into problems with the cache. This PR adds an option to the `ArrowReaderBuilder` to control the predicate cache size.

In order to test that this setting actually works, I also wrote tests.

# What changes are included in this PR?

 Changes:
1. Add `ArrowReaderMetrics` struct that tracks the IO and CPU operations of the reader.
2. Add `ArrowReaderBuilder::with_max_predicate_cache_size` configuration option to control the predicate cache size.
3. Add `ArrowReaderBuilder::with_metrics` for configuring metrics
4. Add tests to ensure that the predicate cache is used correctly and that the metrics are reported accurately.
5. TODO: Hook up the cached reader in the sync reader

# Are these changes tested?
Yes, all the new code is covered by tests

# Are there any user-facing changes?
1. New config options
2. New API to get metrics from the arrow reader