### PR TITLE
Clarify in documentation that cache is only for async decoder

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -788,7 +788,7 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
             limit,
             offset,
             metrics,
-            // TODO: need to implement this for the sync reader
+            // Not used for the sync reader, see https://github.com/apache/arrow-rs/issues/8000
             max_predicate_cache_size: _,
         } = self;
 

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -344,14 +344,20 @@ impl<T> ArrowReaderBuilder<T> {
         Self { metrics, ..self }
     }
 
-    /// Set the maximum size (per row group) of the predicate cache in bytes.
+    /// Set the maximum size (per row group) of the predicate cache in bytes for
+    /// the async decoder.
     ///
-    /// Defaults to 100MB
+    /// Defaults to 100MB (across all columns). Set to `usize::MAX` to use
+    /// unlimited cache size.
     ///
     /// This cache is used to store decoded arrays that are used in
     /// predicate evaluation ([`Self::with_row_filter`]).
     ///
-    /// Set to `usize::MAX` to use unlimited cache size.
+    /// This cache is only used for the "async" decoder, [`ParquetRecordBatchStream`]. See
+    /// [this ticket] for more details and alternatives.
+    ///
+    /// [`ParquetRecordBatchStream`]: https://docs.rs/parquet/latest/parquet/arrow/async_reader/struct.ParquetRecordBatchStream.html
+    /// [this ticket]: https://github.com/apache/arrow-rs/issues/8000
     pub fn with_max_predicate_cache_size(self, max_predicate_cache_size: usize) -> Self {
         Self {
             max_predicate_cache_size,

--- a/parquet/tests/arrow_reader/predicate_cache.rs
+++ b/parquet/tests/arrow_reader/predicate_cache.rs
@@ -38,8 +38,6 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::sync::LazyLock;
 
-// TODO file a ticket about the duplication here
-
 #[tokio::test]
 async fn test_default_read() {
     // The cache is not used without predicates, so we expect 0 records read from cache
@@ -51,16 +49,22 @@ async fn test_default_read() {
 }
 
 #[tokio::test]
-async fn test_cache_with_filters() {
+async fn test_async_cache_with_filters() {
     let test = ParquetPredicateCacheTest::new().with_expected_records_read_from_cache(49);
-    // TODO The sync reader does not use the cache yet....
-    // let sync_builder = test.sync_builder();
-    // let sync_builder = test.add_project_ab_and_filter_b(sync_builder);
-    // test.run_sync(sync_builder);
-
     let async_builder = test.async_builder().await;
     let async_builder = test.add_project_ab_and_filter_b(async_builder);
     test.run_async(async_builder).await;
+}
+
+#[tokio::test]
+async fn test_sync_cache_with_filters() {
+    let test = ParquetPredicateCacheTest::new()
+        // The sync reader does not use the cache. See https://github.com/apache/arrow-rs/issues/8000
+        .with_expected_records_read_from_cache(0);
+
+    let sync_builder = test.sync_builder();
+    let sync_builder = test.add_project_ab_and_filter_b(sync_builder);
+    test.run_sync(sync_builder);
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/pull/7850 

Merging this  PR will update https://github.com/apache/arrow-rs/pull/7850

# Rationale for this change
 
Clarify documentation / tests of the cache. See https://github.com/apache/arrow-rs/pull/7850#issuecomment-3118607666 for more