### PR TITLE
Revert backwards incompatible changes to the Parquet reader API

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -1019,9 +1019,10 @@ impl ParquetRecordBatchReader {
         row_groups: &dyn RowGroups,
         batch_size: usize,
         selection: Option<RowSelection>,
-        metrics: &ArrowReaderMetrics,
     ) -> Result<Self> {
-        let array_reader = ArrayReaderBuilder::new(row_groups, metrics)
+        // note metrics are not supported in this API
+        let metrics = ArrowReaderMetrics::disabled();
+        let array_reader = ArrayReaderBuilder::new(row_groups, &metrics)
             .build_array_reader(levels.levels.as_ref(), &ProjectionMask::all())?;
 
         let read_plan = ReadPlanBuilder::new(batch_size)


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/pull/7850

Merging this PR will update https://github.com/apache/arrow-rs/pull/7850

# Rationale for this change

I would like to minimize breaking changes to the parquet APIs, so instead of add
a new parameter to an existing function, I have added a new function and
deprecated the old one.